### PR TITLE
feat: add labels for rpm-ostree compose image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,20 @@ jobs:
           labels: |
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/vauxite/main/README.md
 
+      - name: Build label flags
+        id: fmt
+        run: |
+          LABELS=$(cat << EOF
+          ${{ steps.meta.outputs.labels }}
+          EOF
+          )
+          IFS=$'\n'
+          OUTPUT=$(for l in $LABELS; do echo -n "-l \"$l\" "; done)
+          echo "::set-output name=labels::$OUTPUT"
+
       - name: Build OSTree container image and push to registry
         uses: Wandalen/wretry.action@master
         with:
-          command: rpm-ostree compose image --initialize --format=registry $(IFS=$'\n'; for l in "${{ steps.meta.outputs.labels }}"; do echo -n "-l \"$l\" "; done) fedora-vauxite.yaml ghcr.io/ublue-os/vauxite:latest
+          command: rpm-ostree compose image --initialize --format=registry ${{ steps.fmt.outputs.labels }} fedora-vauxite.yaml ghcr.io/ublue-os/vauxite:latest
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,6 @@ jobs:
       - name: Build OSTree container image and push to registry
         uses: Wandalen/wretry.action@master
         with:
-          command: rpm-ostree compose image --initialize --format=registry -l ${{ steps.meta.outputs.labels }} fedora-vauxite.yaml ghcr.io/ublue-os/vauxite:latest
+          command: rpm-ostree compose image --initialize --format=registry $(IFS=$'\n'; for l in "${{ steps.meta.outputs.labels }}"; do echo -n "-l \"$l\" "; done) fedora-vauxite.yaml ghcr.io/ublue-os/vauxite:latest
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,18 @@ jobs:
       - name: Login
         run: podman login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
+      - name: Image Metadata
+        uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: |
+            vauxite
+          labels: |
+            io.artifacthub.package.readme-url=https://raw.githubusercontent.com/ublue-os/vauxite/main/README.md
+
       - name: Build OSTree container image and push to registry
         uses: Wandalen/wretry.action@master
         with:
-          command: rpm-ostree compose image --initialize --format=registry fedora-vauxite.yaml ghcr.io/ublue-os/vauxite:latest
+          command: rpm-ostree compose image --initialize --format=registry -l ${{ steps.meta.outputs.labels }} fedora-vauxite.yaml ghcr.io/ublue-os/vauxite:latest
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           )
           IFS=$'\n'
           OUTPUT=$(for l in $LABELS; do echo -n "-l \"$l\" "; done)
-          echo "::set-output name=labels::$OUTPUT"
+          echo "labels=$OUTPUT" >> $GITHUB_OUTPUT
 
       - name: Build OSTree container image and push to registry
         uses: Wandalen/wretry.action@master


### PR DESCRIPTION
This adds a standard set of OCI image labels as well as labels needed for artifacthub during rpm-ostree compose image

This will enable image badges on the website: https://ublue.it/images/ as well as enable vauxite images to be listed in [artifacthub](https://artifacthub.io/packages/search?org=ublue-os&sort=relevance&page=1)

Image base builds use a similar tactic
* https://github.com/ublue-os/base/pull/61
* https://github.com/ublue-os/ubuntu/pull/36
* https://github.com/ublue-os/nvidia/pull/38 